### PR TITLE
Typo fixes in template

### DIFF
--- a/{{cookiecutter.project_name}}/.github/workflows/qc.yml
+++ b/{{cookiecutter.project_name}}/.github/workflows/qc.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ "3.8", "3.9", "3.10" ]
+        python-version: [ "3.9", "3.10" ]
 
     steps:
       - uses: actions/checkout@v3.0.2

--- a/{{cookiecutter.project_name}}/.github/workflows/qc.yml
+++ b/{{cookiecutter.project_name}}/.github/workflows/qc.yml
@@ -28,8 +28,8 @@ jobs:
 
       - name: Check code quality with flake8
         run: poetry run tox -e flake8
-      - name: Check package metadata with Pyroma
-        run: poetry run tox -e pyroma
+      # - name: Check package metadata with Pyroma
+      #   run: poetry run tox -e pyroma
       - name: Check static typing with MyPy
         run: poetry run tox -e mypy
 

--- a/{{cookiecutter.project_name}}/docs/conf.py
+++ b/{{cookiecutter.project_name}}/docs/conf.py
@@ -7,7 +7,7 @@ import os
 import re
 import sys
 from datetime import date
-from {{cookiecutter.project_name}} import __version__
+from {{cookiecutter.__project_slug}} import __version__
 # -- Project information -----------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
 

--- a/{{cookiecutter.project_name}}/pyproject.toml
+++ b/{{cookiecutter.project_name}}/pyproject.toml
@@ -8,7 +8,7 @@ readme = "README.md"
 
 [tool.poetry.dependencies]
 python = "^3.9"
-setuptools = "^64.0.1"
+setuptools = "^65.0.1"
 tox = "^3.25.1"
 click = "^8.1.3"
 importlib = "^1.0.4"

--- a/{{cookiecutter.project_name}}/tests/test_{{cookiecutter.implementation_name}}.py
+++ b/{{cookiecutter.project_name}}/tests/test_{{cookiecutter.implementation_name}}.py
@@ -3,7 +3,7 @@ from tests import TEST_OWL
 import unittest
 
 from oaklib.selector import get_resource_from_shorthand
-from oaklib.implementations import implementation_resolver
+from oaklib.implementations import get_implementation_resolver
 from {{cookiecutter.__project_slug}}.{{cookiecutter.implementation_name}} import {{cookiecutter.implementation}}
 
 class Test{{cookiecutter.implementation}}(unittest.TestCase):
@@ -11,6 +11,7 @@ class Test{{cookiecutter.implementation}}(unittest.TestCase):
         
     def test_plugin(self):
         """tests plugins are discovered"""
+        implementation_resolver = get_implementation_resolver()
         resolved = implementation_resolver.lookup("FOO")
         self.assertEqual(resolved, {{cookiecutter.implementation}})
 


### PR DESCRIPTION
- [x] Since the toml file dictates the min version of python projects, having CI test for v 3.8 in GH actions will throw an error. One of 2 solutions:
1. Either reduce toml version of python support to be 3.8
2. remove v 3.8 tests in GH actions

This PR suggests edit # 2.

 - [x] Bumped version of `setuptools` dependency to ^65.0.1
 - [x] pyroma not implemented in tox
 - [x] get_implementation_resolver should be imported from `oaklib.implementations`