### PR TITLE
Add modules documentation for gh-pages

### DIFF
--- a/{{cookiecutter.project_name}}/.github/workflows/deploy-docs.yml
+++ b/{{cookiecutter.project_name}}/.github/workflows/deploy-docs.yml
@@ -29,6 +29,7 @@ jobs:
         mkdir gh-pages
         touch gh-pages/.nojekyll
         cd docs/
+        poetry run sphinx-apidoc -o . ../src/{{ cookiecutter.__project_slug}}/ --ext-autodoc -f
         poetry run sphinx-build -b html . _build
         cp -r _build/* ../gh-pages/
     

--- a/{{cookiecutter.project_name}}/README.md
+++ b/{{cookiecutter.project_name}}/README.md
@@ -4,4 +4,4 @@
 
 # Acknowledgements
 
-This [cookiecutter](https://cookiecutter.readthedocs.io/en/stable/README.html) project was developed from the [sphintoxetry-cookiecutter](https://github.com/hrshdhgd/sphintoxetry-cookiecutter) template and will be kept up-to-date using [cruft](https://cruft.github.io/cruft/).
+This [cookiecutter](https://cookiecutter.readthedocs.io/en/stable/README.html) project was developed from the [oakx-plugin-cookiecutter](https://github.com/INCATools/oakx-plugin-cookiecutter) template and will be kept up-to-date using [cruft](https://cruft.github.io/cruft/).

--- a/{{cookiecutter.project_name}}/docs/conf.py
+++ b/{{cookiecutter.project_name}}/docs/conf.py
@@ -25,6 +25,7 @@ extensions = [
     "sphinx_rtd_theme",
     "sphinx_click",
     "sphinx_autodoc_typehints",
+    "myst_parser"
 ]
 
 # generate autosummary pages

--- a/{{cookiecutter.project_name}}/docs/index.rst
+++ b/{{cookiecutter.project_name}}/docs/index.rst
@@ -10,7 +10,7 @@ Welcome to {{cookiecutter.project_name}}'s documentation!
    :maxdepth: 2
    :caption: Contents:
 
-
+   modules
 
 Indices and tables
 ==================

--- a/{{cookiecutter.project_name}}/pyproject.toml
+++ b/{{cookiecutter.project_name}}/pyproject.toml
@@ -13,13 +13,14 @@ tox = "^3.25.1"
 click = "^8.1.3"
 importlib = "^1.0.4"
 oaklib = "^0.1"
+sphinx = {version = "^5.3.0", extras = ["docs"]}
+sphinx-rtd-theme = {version = "^1.0.0", extras = ["docs"]}
+sphinx-autodoc-typehints = {version = "^1.19.4", extras = ["docs"]}
+sphinx-click = {version = "^4.3.0", extras = ["docs"]}
+myst-parser = {version = "^0.18.1", extras = ["docs"]}
 
 [tool.poetry.dev-dependencies]
 pytest = "^7.1.2"
-Sphinx = "^5.1.1"
-sphinx-rtd-theme = "^1.0.0"
-sphinx-autodoc-typehints = "^1.19.2"
-sphinx-click = "^4.3.0"
 
 [tool.poetry.scripts]
 {{cookiecutter.project_name}} = "{{cookiecutter.__project_slug}}.cli:main"
@@ -33,6 +34,7 @@ docs = [
     "sphinx-rtd-theme",
     "sphinx-autodoc-typehints",
     "sphinx-click",
+    "myst-parser",
     ]
 
 [tool.black]


### PR DESCRIPTION
Adds:
 - [x] `modules.rst` which basically leads to autogeneration of technical docs for packages
 - [x] Added package `myst-parser` dependency which automatically detects `.md` and convert it into `.html` files
 - [x] Accommodate for the new way of poetry detecting and installing `extras` packages.